### PR TITLE
add windows support

### DIFF
--- a/rows/localization.py
+++ b/rows/localization.py
@@ -13,7 +13,7 @@ import rows.fields
 def locale_context(name, category=locale.LC_ALL):
 
     old_name = locale.getlocale(category)
-    if type(name) is types.UnicodeType:
+    if isinstance(name, types.UnicodeType) and '.' in name:
         name = name.split('.')
     locale.setlocale(category, name)
     rows.fields.SHOULD_NOT_USE_LOCALE = False

--- a/rows/plugins/txt.py
+++ b/rows/plugins/txt.py
@@ -20,8 +20,8 @@ from __future__ import unicode_literals
 from rows.operations import serialize
 from rows.utils import get_filename_and_fobj
 
-
 DASH, PLUS, PIPE = '-', '+', '|'
+
 
 def _max_column_sizes(field_names, table_rows):
     columns = zip(*([field_names] + table_rows))
@@ -34,7 +34,7 @@ def export_to_txt(table, filename_or_fobj, encoding='utf-8', *args, **kwargs):
     # TODO: should use fobj? What about creating a method like json.dumps?
 
     kwargs['encoding'] = encoding
-    filename, fobj = get_filename_and_fobj(filename_or_fobj, mode='w')
+    filename, fobj = get_filename_and_fobj(filename_or_fobj, mode='wb')
     serialized_table = serialize(table, *args, **kwargs)
     field_names = serialized_table.next()
     table_rows = list(serialized_table)

--- a/rows/utils.py
+++ b/rows/utils.py
@@ -21,7 +21,11 @@ import tempfile
 
 from unicodedata import normalize
 
-import magic
+try:
+    import magic
+except ImportError:
+    magic = None
+
 import requests
 
 import rows
@@ -103,7 +107,6 @@ def create_table(data, meta=None, force_headers=None, fields=None,
         else:
             header = make_header(fields.keys())
 
-
         # TODO: may reuse max_columns from html
         max_columns = max(len(row) for row in table_rows)
         assert len(fields) == max_columns
@@ -137,9 +140,12 @@ def download_file(uri):
         content_type = response.headers['content-type']
         plugin_name = content_type.split('/')[-1]
     except (KeyError, IndexError):
-        with magic.Magic() as file_type_guesser:
-            file_type = file_type_guesser.id_buffer(content)
-        plugin_name = file_type.strip().split()[0]
+        if magic:
+            with magic.Magic() as file_type_guesser:
+                file_type = file_type_guesser.id_buffer(content)
+            plugin_name = file_type.strip().split()[0]
+        else:
+            plugin_name = uri.split('/')[-1].split('.')[-1].lower()
 
     tmp = tempfile.NamedTemporaryFile()
     filename = '{}.{}'.format(tmp.name, plugin_name)

--- a/tests/tests_fields.py
+++ b/tests/tests_fields.py
@@ -25,9 +25,14 @@ import types
 from decimal import Decimal
 
 import rows
+import platform
 
 from rows import fields
 
+if platform.system() == 'Windows':
+    locale_name = str('ptb_bra')
+else:
+    locale_name = 'pt_BR.UTF-8'
 
 class FieldsTestCase(unittest.TestCase):
 
@@ -94,7 +99,7 @@ class FieldsTestCase(unittest.TestCase):
                       types.UnicodeType)
         self.assertEqual(fields.IntegerField.deserialize(None), None)
 
-        with rows.locale_context('pt_BR.UTF-8'):
+        with rows.locale_context(locale_name):
             self.assertEqual(fields.IntegerField.serialize(42000), '42000')
             self.assertIs(type(fields.IntegerField.serialize(42000)),
                           types.UnicodeType)
@@ -121,7 +126,7 @@ class FieldsTestCase(unittest.TestCase):
         self.assertIs(type(fields.FloatField.serialize(42.0)),
                       types.UnicodeType)
 
-        with rows.locale_context('pt_BR.UTF-8'):
+        with rows.locale_context(locale_name):
             self.assertEqual(fields.FloatField.serialize(42000.0),
                              '42000,000000')
             self.assertIs(type(fields.FloatField.serialize(42000.0)),
@@ -152,9 +157,11 @@ class FieldsTestCase(unittest.TestCase):
                          Decimal('21.21657469231'))
         self.assertEqual(fields.DecimalField.deserialize(None), None)
 
-        with rows.locale_context('pt_BR.UTF-8'):
-            self.assertEqual(types.UnicodeType,
-                    type(fields.DecimalField.serialize(deserialized)))
+        with rows.locale_context(locale_name):
+            self.assertEqual(
+                types.UnicodeType,
+                type(fields.DecimalField.serialize(deserialized))
+            )
             self.assertEqual(fields.DecimalField.serialize(Decimal('4200')),
                              '4200')
             self.assertEqual(fields.DecimalField.serialize(Decimal('42.0')),
@@ -163,9 +170,13 @@ class FieldsTestCase(unittest.TestCase):
                              '42000,0')
             self.assertEqual(fields.DecimalField.deserialize('42.000,00'),
                              Decimal('42000.00'))
-            self.assertEqual(fields.DecimalField.serialize(Decimal('42000.0'),
-                                                    grouping=True),
-                             '42.000,0')
+            self.assertEqual(
+                fields.DecimalField.serialize(
+                    Decimal('42000.0'),
+                    grouping=True
+                ),
+                '42.000,0'
+            )
 
     def test_PercentField(self):
         deserialized = Decimal('0.42010')
@@ -186,10 +197,11 @@ class FieldsTestCase(unittest.TestCase):
         self.assertEqual(fields.PercentField.serialize(Decimal('42.010')),
                          '4201.0%')
         self.assertEqual(fields.PercentField.serialize(Decimal('0.01')), '1%')
-
-        with rows.locale_context('pt_BR.UTF-8'):
-            self.assertEqual(type(fields.PercentField.serialize(deserialized)),
-                            types.UnicodeType)
+        with rows.locale_context(locale_name):
+            self.assertEqual(
+                type(fields.PercentField.serialize(deserialized)),
+                types.UnicodeType
+            )
             self.assertEqual(fields.PercentField.serialize(Decimal('42.0')),
                              '4200%')
             self.assertEqual(fields.PercentField.serialize(Decimal('42000.0')),
@@ -256,9 +268,13 @@ class FieldsTestCase(unittest.TestCase):
                       types.UnicodeType)
         self.assertIs(type(fields.UnicodeField.deserialize('test')),
                       fields.UnicodeField.TYPE)
-        self.assertEqual(fields.UnicodeField.deserialize('Álvaro'.encode('utf-8'),
-                                                         encoding='utf-8'),
-                         'Álvaro')
+        self.assertEqual(
+            fields.UnicodeField.deserialize(
+                'Álvaro'.encode('utf-8'),
+                encoding='utf-8'
+            ),
+            'Álvaro'
+        )
         self.assertEqual(fields.UnicodeField.deserialize('Álvaro'),
                          'Álvaro')
         self.assertIs(fields.UnicodeField.deserialize(None), None)
@@ -286,11 +302,14 @@ class FieldUtilsTestCase(unittest.TestCase):
                          'date_column': fields.DateField,
                          'datetime_column': fields.DatetimeField,
                          'unicode_column': fields.UnicodeField,
-                         'null_column': fields.ByteField,}
+                         'null_column': fields.ByteField, }
 
     def test_detect_types_utf8(self):
-        result = fields.detect_types(self.fields, self.data,
-                                           encoding='utf-8')
+        result = fields.detect_types(
+            self.fields,
+            self.data,
+            encoding='utf-8'
+        )
         self.assertEqual(type(result), collections.OrderedDict)
         self.assertEqual(result.keys(), self.fields)
         self.assertDictEqual(dict(result), self.expected)

--- a/tests/tests_localization.py
+++ b/tests/tests_localization.py
@@ -18,6 +18,7 @@
 from __future__ import unicode_literals
 
 import unittest
+import platform
 
 import rows
 import rows.fields
@@ -33,6 +34,10 @@ class LocalizationTestCase(unittest.TestCase):
 
     def test_locale_context(self):
         self.assertTrue(rows.fields.SHOULD_NOT_USE_LOCALE)
-        with locale_context('pt_BR.UTF-8'):
+        if platform.system() == 'Windows':
+            name = str('ptb_bra')
+        else:
+            name = 'pt_BR.UTF-8'
+        with locale_context(name):
             self.assertFalse(rows.fields.SHOULD_NOT_USE_LOCALE)
         self.assertTrue(rows.fields.SHOULD_NOT_USE_LOCALE)


### PR DESCRIPTION
- library "magic" is not supported in "windows" .
- locale.setlocale(locale.LC_ALL,'en_US.UTF-8') in the "windows" should be locale.setlocale( locale.LC_ALL, 'ptb_bra')
- "export_to_txt": open the file with 'wb' mode, because the "windows" is placed '\r\n' at the end of lines.