### PR TITLE
Fix filename_or_fobj param on export_to_csv method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Released on: (under development)**
 
+- Fix filename_or_fobj param on export_to_csv method
 - Add `FlexibleTable` class
 - Autodetect delimiter in CSV files
 - Fix StringIO import for Python 3

--- a/rows/plugins/csv.py
+++ b/rows/plugins/csv.py
@@ -42,7 +42,7 @@ def import_from_csv(filename_or_fobj, encoding='utf-8', dialect=None, *args,
     return create_table(csv_reader, meta=meta, *args, **kwargs)
 
 
-def export_to_csv(table, filename_or_fobj, encoding='utf-8', *args, **kwargs):
+def export_to_csv(table, filename_or_fobj=None, encoding='utf-8', *args, **kwargs):
     # TODO: will work only if table.fields is OrderedDict
     # TODO: should use fobj? What about creating a method like json.dumps?
 


### PR DESCRIPTION
Missing 'None' default value for filename_or_fobj param.