### PR TITLE
WIP locale fix

### DIFF
--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -6,6 +6,7 @@ requests
 lxml
 xlrd
 xlwt
+openpyxl
 
 # Test tools
 coverage

--- a/rows/fields.py
+++ b/rows/fields.py
@@ -23,6 +23,8 @@ import locale
 import re
 import types
 
+from locale import localeconv
+
 from decimal import Decimal, InvalidOperation
 
 
@@ -33,6 +35,8 @@ __all__ = ['BoolField', 'IntegerField', 'FloatField', 'DatetimeField',
 REGEXP_ONLY_NUMBERS = re.compile('[^0-9]')
 SHOULD_NOT_USE_LOCALE = True  # This variable is changed by rows.locale_manager
 NULL = (b'-', b'null', b'none', b'nil', b'n/a', b'na')
+DP = localeconv()['decimal_point']
+TS = localeconv()['thousands_sep']
 
 
 class Field(object):
@@ -213,11 +217,11 @@ class DecimalField(Field):
             return value_as_string
         else:
             grouping = kwargs.get('grouping', None)
-            has_decimal_places = value_as_string.find('.') != -1
+            has_decimal_places = value_as_string.find(DP) != -1
             if not has_decimal_places:
                 string_format = '%d'
             else:
-                decimal_places = len(value_as_string.split('.')[1])
+                decimal_places = len(value_as_string.split(DP)[1])
                 string_format = '%.{}f'.format(decimal_places)
             return locale.format(string_format, value, grouping=grouping)
 

--- a/tests/tests_localization.py
+++ b/tests/tests_localization.py
@@ -20,6 +20,8 @@ from __future__ import unicode_literals
 import unittest
 import platform
 
+from locale import getdefaultlocale
+
 import rows
 import rows.fields
 
@@ -37,7 +39,8 @@ class LocalizationTestCase(unittest.TestCase):
         if platform.system() == 'Windows':
             name = str('ptb_bra')
         else:
-            name = 'pt_BR.UTF-8'
+            defaultlocale = getdefaultlocale()
+            name = '{}.{}'.format(defaultlocale[0], defaultlocale[1])
         with locale_context(name):
             self.assertFalse(rows.fields.SHOULD_NOT_USE_LOCALE)
         self.assertTrue(rows.fields.SHOULD_NOT_USE_LOCALE)


### PR DESCRIPTION
Hello, @turicas.

This is not a final PR, it is still a work in progress.

So, the thing is that I get some errors when running the tests on my machine and it looks like it is because I'm missing the pt_BR.UTF-8 locale.

As you can see in `tests/tests_fields.py` I am importing the locale module to find out the current locale and the decimal point and thousand separator. Then I'm using those values to format the numbers for the tests.

I also had to add the locale to the `DecimalField` class, because it was looking for thousand separator considering only dots, not commas.

Still, my tests are not passing because of those small differences when formatting numbers.

Oh, I also added one missing requirement to the development requirements: openpyxl

Can you please have a look and tell if I'm going in the right direction here? Maybe you have some concerns about the way I'm getting the current locale or something. I'm not a Python developer all the time, so I may be missing something :|

Thanks!