### PR TITLE
Add missing openpyxl lib in requirements-dev

### DIFF
--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -6,6 +6,7 @@ requests
 lxml
 xlrd
 xlwt
+openpyxl
 
 # Test tools
 coverage


### PR DESCRIPTION
In development branch, the `openpyxl` is missing in **`requirements-development.txt`**. If you create your environment using this file the tests will break, because this lib was not installed.

Adding this lib to requirements-development.txt fix this issue