### PR TITLE
Accepting CSV's fmtparams on `import_from_csv`  

### DIFF
--- a/rows/plugins/plugin_csv.py
+++ b/rows/plugins/plugin_csv.py
@@ -49,7 +49,7 @@ elif six.PY3:
 
 
 def import_from_csv(filename_or_fobj, encoding='utf-8', dialect=None,
-                    sample_size=8192, *args, **kwargs):
+                    sample_size=8192, fmtparams=None, *args, **kwargs):
     '''Import data from a CSV file
 
     If a file-like object is provided it MUST be in binary mode, like in
@@ -63,7 +63,8 @@ def import_from_csv(filename_or_fobj, encoding='utf-8', dialect=None,
         dialect = discover_dialect(fobj.read(sample_size), encoding)
         fobj.seek(cursor)
 
-    reader = unicodecsv.reader(fobj, encoding=encoding, dialect=dialect)
+    fmtparams = fmtparams or {}
+    reader = unicodecsv.reader(fobj, encoding=encoding, dialect=dialect, **fmtparams)
 
     meta = {'imported_from': 'csv',
             'filename': filename,


### PR DESCRIPTION
@turicas I didn't add tests yet and I'm opening this PR just to make sure if you're ok with this small change on the API would fix #208. 

The usage would be:

```python
data = rows.import_from_csv(fd, fmtparams={'delimiter': ';'})
```

What do you think? If you're ok, I can add tests to this.

PS.: with this change, the old tests keep passing =)