### PR TITLE
Cuducos decompress

### DIFF
--- a/rows/utils.py
+++ b/rows/utils.py
@@ -297,3 +297,8 @@ def export_to_uri(table, uri, *args, **kwargs):
         raise ValueError('Plugin (export) "{}" not found'.format(plugin_name))
 
     return export_function(table, uri, *args, **kwargs)
+
+
+def decompress(path, **kwargs):
+    'Given a zip, gzip or lzma file returns a decompressed file object'
+    pass  # TODO

--- a/rows/utils.py
+++ b/rows/utils.py
@@ -17,6 +17,7 @@
 
 from __future__ import unicode_literals
 
+import bz2
 import cgi
 import gzip
 import mimetypes
@@ -321,16 +322,37 @@ def decompress(path, **kwargs):
     with open(path, 'rb') as handler:
         mime_type = describe_file_type(filename, handler.read())[0]
 
-    mapping = {
-        'application/gzip': gzip.open,
-        'application/gz': gzip.open,
-    }
-    if lzma:
-        mapping.update({
-            'application/x-xz': lzma.open,
-            'application/x-lzma': lzma.open,
-        })
-    open_compressed = mapping.get(mime_type)
+    bz2_mime_types = (
+        'application/bzip2',
+        'application/octet-stream',
+        'application/x-bz2',
+        'application/x-bzip',
+        'application/x-compressed',
+        'application/x-stuffit'
+    )
+    gzip_mime_types = (
+        'application/gzip',
+        'application/x-gzip',
+        'application/x-gunzip',
+        'application/gzipped',
+        'application/gzip-compressed',
+        'application/x-compressed',
+        'application/x-compress',
+        'gzip/document',
+        'application/octet-stream'
+    )
+    lzma_mime_types = (
+        'application/x-xz',
+        'application/x-lzma'
+    )
+
+    open_compressed = None
+    if mime_type in bz2_mime_types:
+        open_compressed = bz2.open
+    if mime_type in gzip_mime_types:
+        open_compressed = gzip.open
+    if lzma and mime_type in lzma_mime_types:
+        open_compressed = lzma.open
 
     if not open_compressed:
         msg = "Couldn't identify file mimetype, or lzma module isn't available"

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -17,11 +17,11 @@
 
 from __future__ import unicode_literals
 
+import bz2
 import gzip
 import os
 import tempfile
 import unittest
-import zipfile
 
 try:
     import lzma
@@ -92,6 +92,13 @@ class UtilsDecompressTestCase(unittest.TestCase):
     def tearDown(self):
         self.temp.cleanup()
 
+    def test_decompress_with_bz2(self):
+        compressed = os.path.join(self.tmp.name, 'test.bz2')
+        with bz2.open(compressed, mode='wb') as compressed_handler:
+            compressed_handler.write(self.contents)
+        decompressed = rows.utils.decompress(compressed)
+        self.assertEqual(self.contents, decompressed.read())
+
     def test_decompress_with_gz(self):
         compressed = os.path.join(self.tmp.name, 'test.gz')
         with gzip.open(compressed, mode='wb') as compressed_handler:
@@ -110,7 +117,7 @@ class UtilsDecompressTestCase(unittest.TestCase):
     @unittest.skipIf(not lzma, 'lzma module not available')
     def test_decompress_with_xz(self):
         compressed = os.path.join(self.tmp.name, 'test.gz')
-        with lzma.open(compressed) as compressed_handilsler:
+        with lzma.open(compressed) as compressed_handler:
             compressed_handler.write(self.contents)
         decompressed = rows.utils.decompress(compressed)
         self.assertEqual(self.contents, decompressed.read())

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -107,25 +107,6 @@ class UtilsDecompressTestCase(unittest.TestCase):
         decompressed = rows.utils.decompress(compressed)
         self.assertEqual(self.contents, decompressed.read())
 
-    def test_decompress_with_zip(self):
-        uncompressed = os.path.join(self.tmp.name, 'test.csv')
-        uncompressed_archived_path = os.path.join('test', 'test.csv')
-        compressed = os.path.join(self.tmp.name, 'test.zip')
-
-        with open(uncompressed, 'w') as uncompressed_handler:
-            uncopressed_handler.write(self.contents)
-
-        with zipfile.ZipFile(compressed, mode='w') as handler:
-            handler.write(uncompressed, arcname=uncompressed_archived_path)
-
-        decompressed = rows.utils.decompress(compressed,
-                                             inner=uncompressed_archived_path)
-        self.assertEqual(self.contents, decompressed.read())
-
-    @unittest.skip('TODO')
-    def test_decompress_with_zip_without_inner(self):
-        pass
-
     @unittest.skip('TODO')
     def test_decompress_with_incompatible_file(self):
         pass


### PR DESCRIPTION
This PR implements `rows.utils.decompress` as suggested in #230. The API is:

```python
import rows
from rows.utils import decompress

table1 = rows.import_from_csv(decompress('filename.csv.gz'))
table2 = rows.import_from_csv(decompress('filename.csv.xz'))
table3 = rows.import_from_csv(decompress('filename.csv.bz2'))
```

A `RunTime` error is raised if:

* `rows` can't properly guess the mimetype as a known mimetype of a lzma or gzip file
* `rows` identifies a lzma mimetype but the `lzma` module is not available (a lzma lib has to be available in the OS when compiling Python it self as [explained here](https://github.com/datasciencebr/jarbas#pythons-lzma-module))