### PR TITLE
missing os import on cli.py

### DIFF
--- a/rows/cli.py
+++ b/rows/cli.py
@@ -25,6 +25,7 @@
 import pathlib
 import sqlite3
 import sys
+import os
 from io import BytesIO
 
 import click


### PR DESCRIPTION
that :)

      File "/home/tian/utz/rows/rows/cli.py", line 103, in cli
        os.makedirs(str(http_cache_path.parent), exist_ok=True)
    NameError: name 'os' is not defined
