### PR TITLE
Add how to setup tox with pyenv to contributing page #241

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *~
 .*.sw?
 .coverage
+htmlcov/
 .directory
 .env
 .idea/*

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ envtest: clean
 	nosetests tests/
 
 test:
+	coverage erase && nosetests -dsv --with-yanc --with-coverage --cover-package rows
+
+test-tox:
 	tox
 
 clean:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -37,13 +37,34 @@ tox -e py27
 tox -e py35
 ```
 
-*tox known issues* : running tox with py27 environ may raise InvocationError in
-non Linux environments. To avoid it you may rebuild tox environment in every
-run with `tox -e py27 -r` or if you want to run nosetests directly:
+### Tox Known Issues
+
+Running tox with py27 environ may raise InvocationError in non Linux 
+environments. To avoid it you may rebuild tox environment in every run with 
+`tox -e py27 -r` or if you want to run nosetests directly:
 
 ```bash
 nosetests -dsv --with-yanc --with-coverage --cover-package rows tests/*.py
 ```
+
+When running tox with pyenv, tox won't find any interpreters NOT in the global 
+path. Make sure all versions are activated with:
+
+```bash
+pyven global {python-version}
+```
+
+For instance, for allowing tox to find python 2.7, 3.5 and 3.6, you'll run: 
+
+```
+pyenv global 2.7.13 3.6.1 3.5.3
+```
+
+Don't forget to add to this all other interpreters you already have enabled: 
+the `pyenv global` command will redefine the global interpreters, not append 
+to them!
+
+### Creating Man Pages
 
 To create the man page you'll need to install [txt2man][txt2man]. In Debian
 (and Debian-based distributions) you can install by running:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -64,6 +64,12 @@ Don't forget to add to this all other interpreters you already have enabled:
 the `pyenv global` command will redefine the global interpreters, not append 
 to them!
 
+**Important**: this will only work with regular virtualenvs. If you're using 
+`pyenv` to manage your virtualenvs, the global interpreters will not be 
+available when the virtualenv is active, and you won't be able to use tox. 
+Either create a standalone virtualenv, or just run the tests with nose, as 
+shown in the previous section.
+
 ### Creating Man Pages
 
 To create the man page you'll need to install [txt2man][txt2man]. In Debian


### PR DESCRIPTION
Adds some instructions on how to get `tox` and `pyenv` to work together, solving #241. Turns out you have to enable all versions required by `tox` with `pyenv global` .

I put the instructions in the _tox know issues_ section, and create some sub-headers for that and for man page creation instructions. Is that a good place to put it, or should I create a different section for the pyenv issue?