### PR TITLE
Fix float conversion 

### DIFF
--- a/rows/fields.py
+++ b/rows/fields.py
@@ -171,7 +171,7 @@ class IntegerField(Field):
             return value
         elif isinstance(value, float):
             new_value = int(value)
-            if new_value != value:
+            if not new_value is value:  # we want 1.0 to be different from 1
                 raise ValueError("It's float, not integer")
             else:
                 value = new_value

--- a/tests/tests_fields.py
+++ b/tests/tests_fields.py
@@ -430,6 +430,19 @@ class FieldUtilsTestCase(unittest.TestCase):
         result = fields.detect_types(self.fields, values)
         self.assertDictEqual(dict(result), expected)
 
+    def test_detect_types_float_int(self):
+        '''detect_types must preserve object type
+
+        From issue: https://github.com/turicas/rows/issues/198
+        '''
+
+        field_names = ['field1', 'field2']
+        expected = {'field1': fields.IntegerField,
+                    'field2': fields.FloatField, }
+
+        assert expected == fields.detect_types(field_names, [[42, 1.2]])
+        assert expected == fields.detect_types(field_names, [[42, 1.0]])
+
     def test_detect_types(self):
         result = fields.detect_types(self.fields, self.data)
         self.assertDictEqual(dict(result), self.expected)


### PR DESCRIPTION
As described in #198:

* the attempt detect the type of `'1.0'` (a string) would (correctly) suggest `FloatField`
* but the attempt do detect the type of `1.0` (a float) would (wrongly) suggest `IntegerField`

This was probably due to this comparison in the `IntegerField.deserialize` method:

```python
        …
        elif isinstance(value, float):
            new_value = int(value)
            if new_value != value:
        …
```

As indeed `1 == 1.0`, this might be causing the wrongly type detection. Thus I'm suggesting `is` instead — in other words `1 == 1.0` passes, but `1 is 1.0` doesn't.

That fixes the issues and make tests suggested in the issue pass ; )