### PR TITLE
Create options to export pretty text table frames (frame_style)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -30,3 +30,4 @@ Created and maintained by Álvaro Justen aka turicas:
 - Sebastian Oliva <https://github.com/tian2992>
 - Guillermo Colmenero <https://github.com/narrowfail>
 - Izabela Borges <https://github.com/izabelacborges>
+- João S. O. Bueno <https://github.com/jsbueno>

--- a/rows/cli.py
+++ b/rows/cli.py
@@ -320,10 +320,11 @@ def print_(input_encoding, output_encoding, input_locale, output_locale,
 @click.option('--output-locale')
 @click.option('--verify-ssl', default=True, type=bool)
 @click.option('--output')
+@click.option('--frame_style', default='ASCII')
 @click.argument('query', required=True)
 @click.argument('sources', nargs=-1, required=True)
 def query(input_encoding, output_encoding, input_locale, output_locale,
-          verify_ssl, output, query, sources):
+          verify_ssl, output, frame_style, query, sources):
 
     if not query.lower().startswith('select'):
         table_names = ', '.join(['table{}'.format(index)
@@ -378,9 +379,11 @@ def query(input_encoding, output_encoding, input_locale, output_locale,
         fobj = BytesIO()
         if output_locale is not None:
             with rows.locale_context(output_locale):
-                rows.export_to_txt(result, fobj, encoding=output_encoding)
+                rows.export_to_txt(result, fobj, encoding=output_encoding,
+                                   frame_style=frame_style)
         else:
-            rows.export_to_txt(result, fobj, encoding=output_encoding)
+            rows.export_to_txt(result, fobj, encoding=output_encoding,
+                               frame_style=frame_style)
         fobj.seek(0)
         click.echo(fobj.read())
     else:

--- a/rows/plugins/txt.py
+++ b/rows/plugins/txt.py
@@ -17,28 +17,34 @@
 
 from __future__ import unicode_literals
 
+import re
 import unicodedata
 from collections import defaultdict
 
 from rows.plugins.utils import (create_table, export_data,
                                 get_filename_and_fobj, serialize)
 
-
-
 single_frame_prefix = "BOX DRAWINGS LIGHT"
 double_frame_prefix = "BOX DRAWINGS DOUBLE"
-frame_parts = [name.strip() for name in """
+frame_parts = [
+    name.strip() for name in """
     VERTICAL, HORIZONTAL, DOWN AND RIGHT, DOWN AND LEFT,
     UP AND RIGHT, UP AND LEFT, VERTICAL AND LEFT, VERTICAL AND RIGHT,
-    DOWN AND HORIZONTAL, UP AND HORIZONTAL, VERTICAL AND HORIZONTAL""".split(',')
+    DOWN AND HORIZONTAL, UP AND HORIZONTAL,
+    VERTICAL AND HORIZONTAL""".split(',')
 ]
 
+# Rendered characters inserted in comments
+# for grepping/visualization purposes.
+
+# ['│', '─', '┌', '┐', '└', '┘', '┤', '├', '┬', '┴', '┼']
 SINGLE_FRAME = {
     name.strip(): unicodedata.lookup(
         ' '.join((single_frame_prefix, name.strip())))
     for name in frame_parts
 }
 
+# ['║', '═', '╔', '╗', '╚', '╝', '╣', '╠', '╦', '╩', '╬']
 DOUBLE_FRAME = {
     name.strip(): unicodedata.lookup(
         ' '.join((double_frame_prefix, name.strip())))
@@ -61,6 +67,56 @@ FRAMES = {
 del single_frame_prefix, double_frame_prefix, frame_parts
 del NONE_FRAME, ASCII_FRAME, SINGLE_FRAME, DOUBLE_FRAME
 
+FRAME_SENTINEL = object()
+
+
+def _parse_frame_style(frame_style):
+    if frame_style is None:
+        frame_style = 'None'
+    try:
+        FRAMES[frame_style]
+    except KeyError as error:
+        raise ValueError(
+            "Invalid frame style '{}'. Use one of 'None', "
+            "'ASCII', 'single' or 'double'.".format(frame_style)
+        )
+    return frame_style
+
+
+def _guess_frame_style(contents):
+    first_line_chars = set(contents.split('\n')[0].strip())
+    for frame_style, frame_dict in FRAMES.items():
+        if first_line_chars <= set(frame_dict.values()):
+            return frame_style
+    return 'None'
+
+
+def _parse_col_positions(frame_style, header_line):
+    """Find the position for each column separator in the given line
+
+    If frame_style is 'None', this won work
+    for column names that _start_ with whitespace
+    (which includes non-lefthand aligned column titles)
+    """
+
+    separator = re.escape(FRAMES[frame_style]['VERTICAL'])
+
+    if frame_style == 'None':
+        separator = r"[\s]{2}[^\s]"
+        # Matches two whitespaces followed by a non-whitespace.
+        # Our column headers are serated by 3 spaces by default.
+
+    col_positions = []
+    # Abuse regexp engine to anotate vertical-separator positions:
+    re.sub(
+        separator,
+        lambda group: col_positions.append(group.start()),
+        header_line
+    )
+    if frame_style == 'None':
+        col_positions.append(len(header_line) - 1)
+    return col_positions
+
 
 def _max_column_sizes(field_names, table_rows):
     columns = zip(*([field_names] + table_rows))
@@ -68,29 +124,61 @@ def _max_column_sizes(field_names, table_rows):
             for field_name, column in zip(field_names, columns)}
 
 
-def import_from_txt(filename_or_fobj, encoding='utf-8', *args, **kwargs):
-    # TODO: should be able to change DASH, PLUS and PIPE
+def import_from_txt(filename_or_fobj, encoding='utf-8',
+                    frame_style=FRAME_SENTINEL, *args, **kwargs):
 
-    DASH, PLUS, PIPE = '-+|'
+    # TODO: (maybe)
+    # enable parsing of non-fixed-width-columns
+    # with old algorithm - that would just split columns
+    # at the vertical separator character for the frame.
+    # (if doing so, include an optional parameter)
+    #
+
+    # Also, this fixes an outstanding unreported issue:
+    # trying to parse tables which fields values
+    # included a Pipe char - "|" - would silently
+    # yield bad results.
 
     filename, fobj = get_filename_and_fobj(filename_or_fobj, mode='rb')
-    contents = fobj.read().decode(encoding).strip().splitlines()
+    raw_contents = fobj.read().decode(encoding).rstrip('\n')
 
-    # remove '+----+----+' lines
-    contents = contents[1:-1]
-    del contents[1]
+    if frame_style is FRAME_SENTINEL:
+        frame_style = _guess_frame_style(raw_contents)
+    else:
+        frame_style = _parse_frame_style(frame_style)
 
-    table_rows = [[value.strip() for value in row.split(PIPE)[1:-1]]
-                  for row in contents]
+    contents = raw_contents.splitlines()
+    del raw_contents
+
+    if frame_style != 'None':
+        contents = contents[1:-1]
+        del contents[1]
+    else:
+        # the table is possibly generated from other source.
+        # check if the line we reserve as a separator is realy empty.
+        if not contents[1].strip():
+            del contents[1]
+    col_positions = _parse_col_positions(frame_style, contents[0])
+
+    table_rows = [
+        [row[start + 1: end].strip()
+            for start, end in zip(col_positions, col_positions[1:])]
+        for row in contents]
+    #
+    # Variable columns - old behavior:
+    # table_rows = [[value.strip() for value in row.split(vertical_char)[1:-1]]
+    #              for row in contents]
+
     meta = {'imported_from': 'txt',
             'filename': filename,
-            'encoding': encoding,}
+            'encoding': encoding,
+            'frame_style': frame_style}
     return create_table(table_rows, meta=meta, *args, **kwargs)
 
 
 def export_to_txt(table, filename_or_fobj=None, encoding=None,
-                  frame_style="ASCII", *args, **kwargs):
-    '''Export a `rows.Table` to text
+                  frame_style="ASCII", safe_none_frame=True, *args, **kwargs):
+    """Export a `rows.Table` to text
 
     This function can return the result as a string or save into a file (via
     filename or file-like object).
@@ -102,24 +190,32 @@ def export_to_txt(table, filename_or_fobj=None, encoding=None,
     Valid values are: ('None', 'ASCII', 'single', 'double') - ASCII is default.
     Warning: no checks are made to check the desired encoding allows the
     characters needed by single and double frame styles.
-    '''
+
+    `safe_none_frame`: bool, defaults to True. Affects only output with
+    frame_style == "None":
+    column titles are left-aligned and have
+    whitespace replaced for "_".  This enables
+    the output to be parseable. Otherwise, the generated table will look
+    prettier but can not be imported back.
+    """
     # TODO: will work only if table.fields is OrderedDict
 
-    try:
-        frame = FRAMES[frame_style]
-    except KeyError as error:
-        raise ValueError(
-            "Invalid frame style '{}'. Use one of None, "
-            "'ASCII', 'single' or 'double'.".format(frame_style)
-        )
+    frame_style = _parse_frame_style(frame_style)
+    frame = FRAMES[frame_style]
 
     serialized_table = serialize(table, *args, **kwargs)
     field_names = next(serialized_table)
     table_rows = list(serialized_table)
     max_sizes = _max_column_sizes(field_names, table_rows)
 
-    dashes = [frame['HORIZONTAL'] * (max_sizes[field] + 2) for field in field_names]
-    header = [field.center(max_sizes[field]) for field in field_names]
+    dashes = [frame['HORIZONTAL'] * (max_sizes[field] + 2)
+              for field in field_names]
+
+    if frame_style != 'None' or not safe_none_frame:
+        header = [field.center(max_sizes[field]) for field in field_names]
+    else:
+        header = [field.replace(" ", "_").ljust(max_sizes[field])
+                  for field in field_names]
     header = '{0} {1} {0}'.format(
         frame['VERTICAL'],
         ' {} '.format(frame['VERTICAL']).join(header)
@@ -142,14 +238,20 @@ def export_to_txt(table, filename_or_fobj=None, encoding=None,
         frame['UP AND LEFT']
     )
 
+    result = []
+    if frame_style != 'None':
+        result += [top_split_line]
+    result += [header, body_split_line]
 
-    result = [top_split_line, header, body_split_line]
     for row in table_rows:
         values = [value.rjust(max_sizes[field_name])
                   for field_name, value in zip(field_names, row)]
         row_data = ' {} '.format(frame['VERTICAL']).join(values)
         result.append('{0} {1} {0}'.format(frame['VERTICAL'], row_data))
-    result.extend([botton_split_line, ''])
+
+    if frame_style != 'None':
+        result.append(botton_split_line)
+    result.append('')
     data = '\n'.join(result)
 
     if encoding is not None:

--- a/tests/tests_plugin_txt.py
+++ b/tests/tests_plugin_txt.py
@@ -17,6 +17,7 @@
 
 from __future__ import unicode_literals
 
+import sys
 import tempfile
 import unittest
 from collections import OrderedDict
@@ -55,7 +56,7 @@ class PluginTxtTestCase(utils.RowsTestMixIn, unittest.TestCase):
         call = mocked_create_table.call_args
         kwargs['meta'] = {'imported_from': 'txt',
                           'filename': self.filename,
-                          'encoding': self.encoding,}
+                          'encoding': self.encoding, }
         self.assertEqual(call[1], kwargs)
 
     @mock.patch('rows.plugins.txt.create_table')
@@ -136,8 +137,9 @@ class PluginTxtTestCase(utils.RowsTestMixIn, unittest.TestCase):
         filename = '{}.{}'.format(temp.name, self.file_extension)
         self.files_to_delete.append(filename)
 
-        table = rows.Table(fields=
-                OrderedDict([('jsoncolumn', rows.fields.JSONField)]))
+        table = rows.Table(
+            fields=OrderedDict([('jsoncolumn', rows.fields.JSONField)])
+        )
         table.append({'jsoncolumn': '{"python": 42}'})
         rows.export_to_txt(table, filename, encoding='utf-8')
 
@@ -147,3 +149,41 @@ class PluginTxtTestCase(utils.RowsTestMixIn, unittest.TestCase):
     def test_export_to_text_should_return_unicode(self):
         result = rows.export_to_txt(utils.table)
         self.assertEqual(type(result), six.text_type)
+
+    def _test_export_to_txt_frame_style(self,
+                                        frame_style,
+                                        chars,
+                                        positive=True):
+        temp = tempfile.NamedTemporaryFile(delete=False)
+        self.files_to_delete.append(temp.name)
+        rows.export_to_txt(utils.table, temp.file, encoding='utf-8',
+                           frame_style=frame_style)
+
+        if sys.version_info.major < 3:
+            from io import open as open_
+        else:
+            open_ = open
+
+        file_data = open_(temp.name, 'rt', encoding='utf-8').read()
+
+        for char in chars:
+            if positive:
+                self.assertIn(char, file_data)
+            else:
+                self.assertNotIn(char, file_data)
+
+    def test_export_to_txt_frame_style_ASCII(self):
+        self._test_export_to_txt_frame_style(frame_style='ASCII', chars='+-|')
+
+    def test_export_to_txt_frame_style_single(self):
+        self._test_export_to_txt_frame_style(frame_style='single',
+                                             chars='│┤┐└┬├─┼┘┌')
+
+    def test_export_to_txt_frame_style_double(self):
+        self._test_export_to_txt_frame_style(frame_style='double',
+                                             chars='╣║╗╝╚╔╩╦╠═╬')
+
+    def test_export_to_txt_frame_style_none(self):
+        self._test_export_to_txt_frame_style(frame_style='None',
+                                             chars='|│┤┐└┬├─┼┘┌╣║╗╝╚╔╩╦╠═╬',
+                                             positive=False)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -178,6 +178,12 @@ class RowsTestMixIn(object):
             if self.assert_meta_encoding:
                 expected_meta['encoding'] = self.encoding
 
+        # Don't test 'frame_style' metadata,
+        # as it is specific for txt importing
+        # (and the default values for it might change)
+        if "frame_style" not in expected_meta:
+            kwargs['meta'].pop('frame_style', '')
+
         self.assertEqual(kwargs['meta'], expected_meta)
         del kwargs['meta']
         self.assert_table_data(call_args[0][0], args=[], kwargs=kwargs,


### PR DESCRIPTION
Add unicode box-drawing characters as options when exporting text in tabular data

Also, keeps the current frame style the default, named as 'ASCII' using the -+| characters, and
add the 'None' frame style to use just spaces where the box drawing characters would be.

