### PR TITLE
Fixes issue #286 "Text plugin is not working on `rows convert`"

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,8 @@
 - [#270](https://github.com/turicas/rows/pull/270) Added options to export
   pretty text table frames (TXT plugin)
 - Add `csv2sqlite` CLI subcommand
+- Create `rows.utils.open_compressed` helper function: can read/write files,
+  automatically dealing with on-the-fly compression
 - [#274](https://github.com/turicas/rows/issues/274) `start_row` and
   `start_column` now behave the same way in XLS and XLSX
 - [#261](https://github.com/turicas/rows/issues/261) Add support to `end_row`

--- a/rows/cli.py
+++ b/rows/cli.py
@@ -272,7 +272,8 @@ def sum_(input_encoding, output_encoding, input_locale, output_locale,
 @click.option('--output-encoding')
 @click.option('--input-locale')
 @click.option('--output-locale')
-@click.option('--frame-style', default='ASCII')
+@click.option('--frame-style', default='ASCII',  help=
+              'Options: ASCII, single, double, none. Defaults to ASCII')
 @click.option('--table-index', default=0)
 @click.option('--verify-ssl', default=True, type=bool)
 @click.option('--fields',
@@ -332,7 +333,8 @@ def print_(input_encoding, output_encoding, input_locale, output_locale, frame_s
 @click.option('--samples', type=int, default=5000,
               help='Number of rows to determine the field types (0 = all)')
 @click.option('--output')
-@click.option('--frame-style', default='ASCII')
+@click.option('--frame-style', default='ASCII', help=
+              'Options: ASCII, single, double, none. Defaults to ASCII')
 @click.argument('query', required=True)
 @click.argument('sources', nargs=-1, required=True)
 def query(input_encoding, output_encoding, input_locale, output_locale,

--- a/rows/cli.py
+++ b/rows/cli.py
@@ -272,6 +272,7 @@ def sum_(input_encoding, output_encoding, input_locale, output_locale,
 @click.option('--output-encoding')
 @click.option('--input-locale')
 @click.option('--output-locale')
+@click.option('--frame-style', default='ASCII')
 @click.option('--table-index', default=0)
 @click.option('--verify-ssl', default=True, type=bool)
 @click.option('--fields',
@@ -280,7 +281,7 @@ def sum_(input_encoding, output_encoding, input_locale, output_locale,
               help='A comma-separated list of fields to exclude')
 @click.option('--order-by')
 @click.argument('source', required=True)
-def print_(input_encoding, output_encoding, input_locale, output_locale,
+def print_(input_encoding, output_encoding, input_locale, output_locale, frame_style,
            table_index, verify_ssl, fields, fields_exclude, order_by, source):
 
     import_fields = _get_import_fields(fields, fields_exclude)
@@ -312,10 +313,10 @@ def print_(input_encoding, output_encoding, input_locale, output_locale,
     if output_locale is not None:
         with rows.locale_context(output_locale):
             rows.export_to_txt(table, fobj, encoding=output_encoding,
-                               export_fields=export_fields)
+                               export_fields=export_fields, frame_style=frame_style)
     else:
         rows.export_to_txt(table, fobj, encoding=output_encoding,
-                           export_fields=export_fields)
+                           export_fields=export_fields, frame_style=frame_style)
 
     fobj.seek(0)
     # TODO: may pass unicode to click.echo if output_encoding is not provided

--- a/rows/cli.py
+++ b/rows/cli.py
@@ -456,9 +456,11 @@ def schema(input_encoding, input_locale, verify_ssl, output_format, fields,
 @click.option('--batch_size', default=10000)
 @click.option('--samples', default=5000)
 @click.option('--input-encoding', default='utf-8')
+@click.option('--dialect', default=None)
 @click.argument('sources', nargs=-1, required=True)
 @click.argument('output', required=True)
-def command_csv2sqlite(batch_size, samples, input_encoding, sources, output):
+def command_csv2sqlite(batch_size, samples, input_encoding, dialect, sources,
+                       output):
 
     inputs = [pathlib.Path(filename) for filename in sources]
     output = pathlib.Path(output)
@@ -475,6 +477,7 @@ def command_csv2sqlite(batch_size, samples, input_encoding, sources, output):
         csv2sqlite(
             six.text_type(filename),
             six.text_type(output),
+            dialect=dialect,
             table_name=table_name,
             samples=samples,
             batch_size=batch_size,
@@ -486,10 +489,11 @@ def command_csv2sqlite(batch_size, samples, input_encoding, sources, output):
 
 @cli.command(name='sqlite2csv', help='Convert a SQLite table into CSV')
 @click.option('--batch_size', default=10000)
+@click.option('--dialect', default='excel')
 @click.argument('source', required=True)
 @click.argument('table_name', required=True)
 @click.argument('output', required=True)
-def command_sqlite2csv(batch_size, source, table_name, output):
+def command_sqlite2csv(batch_size, dialect, source, table_name, output):
 
     input_filename = pathlib.Path(source)
     output_filename = pathlib.Path(output)
@@ -502,6 +506,7 @@ def command_sqlite2csv(batch_size, source, table_name, output):
     sqlite2csv(
         input_filename=six.text_type(input_filename),
         table_name=table_name,
+        dialect=dialect,
         output_filename=six.text_type(output_filename),
         batch_size=batch_size,
         callback=progress.update,
@@ -512,11 +517,12 @@ def command_sqlite2csv(batch_size, source, table_name, output):
 @cli.command(name='pgimport', help='Import a CSV file into a PostgreSQL table')
 @click.option('--input-encoding', default='utf-8')
 @click.option('--no-create-table', type=bool, default=False)
+@click.option('--dialect', default=None)
 @click.argument('source', required=True)
 @click.argument('database_uri', required=True)
 @click.argument('table_name', required=True)
-def command_pgimport(input_encoding, no_create_table, source, database_uri,
-                     table_name):
+def command_pgimport(input_encoding, no_create_table, dialect, source,
+                     database_uri, table_name):
 
     progress = ProgressBar(
         prefix='Importing data',
@@ -533,6 +539,7 @@ def command_pgimport(input_encoding, no_create_table, source, database_uri,
     import_meta = pgimport(
         filename=source,
         encoding=input_encoding,
+        dialect=dialect,
         database_uri=database_uri,
         create_table=not no_create_table,
         table_name=table_name,
@@ -545,10 +552,12 @@ def command_pgimport(input_encoding, no_create_table, source, database_uri,
 
 @cli.command(name='pgexport', help='Export a PostgreSQL table into a CSV file')
 @click.option('--output-encoding', default='utf-8')
+@click.option('--dialect', default='excel')
 @click.argument('database_uri', required=True)
 @click.argument('table_name', required=True)
 @click.argument('destination', required=True)
-def command_pgexport(output_encoding, database_uri, table_name, destination):
+def command_pgexport(output_encoding, dialect, database_uri, table_name,
+                     destination):
 
     updater = ProgressBar(prefix='Exporting data', unit='bytes')
     pgexport(
@@ -556,6 +565,7 @@ def command_pgexport(output_encoding, database_uri, table_name, destination):
         table_name=table_name,
         filename=destination,
         encoding=output_encoding,
+        dialect=dialect,
         callback=updater.update,
     )
     updater.close()

--- a/rows/plugins/plugin_csv.py
+++ b/rows/plugins/plugin_csv.py
@@ -27,6 +27,15 @@ from rows.plugins.utils import (create_table, get_filename_and_fobj,
 
 sniffer = unicodecsv.Sniffer()
 
+def fix_dialect(dialect):
+    if not dialect.doublequote and dialect.escapechar is None:
+        dialect.doublequote = True
+
+    if dialect.quoting == unicodecsv.QUOTE_MINIMAL and dialect.quotechar == "'":
+        # Python csv's Sniffer seems to detect a wrong quotechar when
+        # quoting is minimal
+        dialect.quotechar = '"'
+
 if six.PY2:
 
     def discover_dialect(sample, encoding=None,
@@ -41,9 +50,7 @@ if six.PY2:
         except unicodecsv.Error:  # Couldn't detect: fall back to 'excel'
             dialect = unicodecsv.excel
 
-        if not dialect.doublequote and dialect.escapechar is None:
-            dialect.doublequote = True
-
+        fix_dialect(dialect)
         return dialect
 
 elif six.PY3:
@@ -78,9 +85,7 @@ elif six.PY3:
         except unicodecsv.Error:  # Couldn't detect: fall back to 'excel'
             dialect = unicodecsv.excel
 
-        if not dialect.doublequote and dialect.escapechar is None:
-            dialect.doublequote = True
-
+        fix_dialect(dialect)
         return dialect
 
 

--- a/rows/plugins/txt.py
+++ b/rows/plugins/txt.py
@@ -51,7 +51,7 @@ DOUBLE_FRAME = {
     for name in frame_parts
 }
 
-ASCII_FRAME = defaultdict(lambda: '+')
+ASCII_FRAME = {name: '+' for name in frame_parts}
 ASCII_FRAME['HORIZONTAL'] = '-'
 ASCII_FRAME['VERTICAL'] = '|'
 

--- a/rows/utils.py
+++ b/rows/utils.py
@@ -648,8 +648,8 @@ def get_psql_copy_command(table_name, header, encoding='utf-8',
         "ENCODING '{encoding}' "
         "CSV HEADER;"
     ).format(table_name=table_name, header=header, direction=direction,
-             delimiter=dialect.delimiter.replace("'", "\\'"),
-             quote=dialect.quotechar.replace("'", "\\'"), encoding=encoding)
+             delimiter=dialect.delimiter.replace("'", "''"),
+             quote=dialect.quotechar.replace("'", "''"), encoding=encoding)
 
     return get_psql_command(copy, user=user, password=password, host=host,
                             port=port, database_name=database_name,

--- a/tests/tests_plugin_postgresql.py
+++ b/tests/tests_plugin_postgresql.py
@@ -61,10 +61,8 @@ class PluginPostgreSQLTestCase(utils.RowsTestMixIn, unittest.TestCase):
         return result
 
     def tearDown(self):
-        print('running tear down', flush=True)
         connection = pgconnect(self.uri)
         for table in self.get_table_names():
-            print('table ' + table, flush=True)
             if table.startswith('rows_'):
                 cursor = connection.cursor()
                 cursor.execute('DROP TABLE ' + table)

--- a/tests/tests_plugin_sqlite.py
+++ b/tests/tests_plugin_sqlite.py
@@ -204,6 +204,6 @@ class PluginSqliteTestCase(utils.RowsTestMixIn, unittest.TestCase):
         rows.export_to_sqlite(table, ':memory:', callback=myfunc, batch_size=3)
         self.assertEqual(myfunc.call_count, 4)
         self.assertEqual(
-            [x[0][0] for x in myfunc.call_args_list],
-            [3, 6, 9, 10]
+            [(x[0][0], x[0][1]) for x in myfunc.call_args_list],
+            [(3, 3), (3, 6), (3, 9), (1, 10)]
         )

--- a/tests/tests_plugin_txt.py
+++ b/tests/tests_plugin_txt.py
@@ -199,7 +199,6 @@ class PluginTxtTestCase(utils.RowsTestMixIn, unittest.TestCase):
     def _test_import_from_txt_works_with_custom_frame(self, frame_style):
         temp = tempfile.NamedTemporaryFile(delete=False)
         # self.files_to_delete.append(temp.name)
-        print("*" * 100, temp.name)
 
         original_data = rows.import_from_txt(self.filename)
         rows.export_to_txt(utils.table, temp.file, encoding='utf-8',

--- a/tests/tests_plugin_txt.py
+++ b/tests/tests_plugin_txt.py
@@ -195,15 +195,35 @@ class PluginTxtTestCase(utils.RowsTestMixIn, unittest.TestCase):
         self._test_export_to_txt_frame_style(frame_style='None',
                                              chars='|│┤┐└┬├─┼┘┌╣║╗╝╚╔╩╦╠═╬',
                                              positive=False)
+    @staticmethod
+    def _reset_txt_plugin():
+        # The txt plugin makes (or can make use) of 'defaultdict's
+        # and perform certain operations against their existing values.
+        # Those existing values may change if certain txt operations
+        # are performed in the same proccess.
+        # Therefore, some tests have to run against
+        # pristine copies of rows.plugins.txt
+        try:
+            from imp import reload
+        except ImportError:
+            pass
+        import rows.plugins.txt
+
+        original_txt_plugin = rows.plugins.txt
+        reload(rows.plugins.txt)
+        rows.import_from_txt = rows.plugins.txt.import_from_txt
+        rows.export_to_txt = rows.plugins.txt.export_to_txt
+        original_txt_plugin.FRAME_SENTINEL = rows.plugins.txt.FRAME_SENTINEL
 
     def _test_import_from_txt_works_with_custom_frame(self, frame_style):
         temp = tempfile.NamedTemporaryFile(delete=False)
-        # self.files_to_delete.append(temp.name)
 
         original_data = rows.import_from_txt(self.filename)
         rows.export_to_txt(utils.table, temp.file, encoding='utf-8',
                            frame_style=frame_style)
 
+
+        self._reset_txt_plugin()
         new_data = rows.import_from_txt(temp.name)
 
         self.assertEqual(


### PR DESCRIPTION
It was actually a subtle bug , that would only affect the text import plug-in if no text export had already been used  on the same process. 

The existing tests would not catch it: the values() on the defaultdict containing the characters used for the ASCII frame where always "warmed up" to contain all valid values, before the text import tests where run.

(The actual fix is far simpler than the changes the text to detect the condition if it ever happens again).

Also, this enables the `--frame-style` option on the "print" command - its availability only on the  `query` command was actually a bug. 