### PR TITLE
add a reference to install cli dependencies

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,6 +9,15 @@ converting and querying data.
 > available][cli-manpage].
 
 
+## Getting started
+
+Before using the command-line interface, you must first install the
+dependencies required by the module:
+
+```bash
+pip install rows[cli]
+```
+
 ## Commands
 
 All the commands accepts any of the formats supported by the library (unless


### PR DESCRIPTION
to make it clearer in documentation that the user must install specific dependencies before using the CLI.