### PR TITLE
Txt line break

### DIFF
--- a/rows/utils.py
+++ b/rows/utils.py
@@ -763,7 +763,7 @@ def get_psql_copy_command(
         header = ", ".join(slug(field_name) for field_name in header)
         header = "({header}) ".format(header=header)
     copy = (
-        "\copy {table_name} {header}{direction} STDIN "
+        r"\copy {table_name} {header}{direction} STDIN "
         "DELIMITER '{delimiter}' "
         "QUOTE '{quote}' "
         "ENCODING '{encoding}' "

--- a/tests/data/line_break.csv
+++ b/tests/data/line_break.csv
@@ -1,0 +1,5 @@
+nome,endereco
+José da Silva,"Rua dos Bobos, 0
+Cidade Fantasma"
+"José Maria
+(Zé Maria)","R. XPTO, 1"

--- a/tests/tests_plugin_txt.py
+++ b/tests/tests_plugin_txt.py
@@ -255,14 +255,15 @@ class PluginTxtTestCase(utils.RowsTestMixIn, unittest.TestCase):
             original_data, temp.file, encoding="utf-8", frame_style="ASCII",
         )
         expected_output = dedent("""\
-            +-----------------------+----------------------------------+
-            |          nome         |             endereco             |
-            +-----------------------+----------------------------------+
-            | José da Silva         | Rua dos Bobos, 0                 |
-            |                       | Cidade Fantasma                  |
-            | José Maria            |                       R. XPTO, 1 |
-            | (Zé Maria)            |                                  |
-            +-----------------------+----------------------------------+
+            +---------------+------------------+
+            |      nome     |     endereco     |
+            +---------------+------------------+
+            | José da Silva | Rua dos Bobos, 0 |
+            |               |  Cidade Fantasma |
+            |               |                  |
+            |    José Maria |       R. XPTO, 1 |
+            |    (Zé Maria) |                  |
+            +---------------+------------------+
             """)
 
         temp.seek(0)

--- a/tests/tests_plugin_txt.py
+++ b/tests/tests_plugin_txt.py
@@ -21,6 +21,7 @@ import sys
 import tempfile
 import unittest
 from collections import OrderedDict
+from textwrap import dedent
 
 import mock
 import six
@@ -244,3 +245,27 @@ class PluginTxtTestCase(utils.RowsTestMixIn, unittest.TestCase):
         self.assertEqual(result1, [0, 5, 10])
         result2 = rows.plugins.txt._parse_col_positions("None", "  col1   col2  ")
         self.assertEqual(result2, [0, 7, 14])
+
+
+    def test_data_with_line_breaks_correctly_formated(self):
+        temp = tempfile.NamedTemporaryFile(delete=False)
+
+        original_data = rows.import_from_csv("tests/data/line_break.csv")
+        rows.export_to_txt(
+            original_data, temp.file, encoding="utf-8", frame_style="ASCII",
+        )
+        expected_output = dedent("""\
+            +-----------------------+----------------------------------+
+            |          nome         |             endereco             |
+            +-----------------------+----------------------------------+
+            | José da Silva         | Rua dos Bobos, 0                 |
+            |                       | Cidade Fantasma                  |
+            | José Maria            |                       R. XPTO, 1 |
+            | (Zé Maria)            |                                  |
+            +-----------------------+----------------------------------+
+            """)
+
+        temp.seek(0)
+        text_data = temp.read().decode("utf-8")
+
+        self.assertEqual(text_data, expected_output)


### PR DESCRIPTION
This PR fixes the immediate issues exposed at
https://gist.github.com/turicas/8bd86dd425d2212dbe214d725121be7c?fbclid=IwAR1VitQE02l7OiCjCKDsdYTJJ9-mC53xlFOD2yhWoxZyCPWrjqchl7H7CPo

That is - any cell containing a line-feed character breaks the text-plugin output. 

Besides creating multiline cells in the text output, the code also includes a "blank" line bellow any row having a multi-line cell, so that contents are visually separateted.

Not covered by this code: Parsing back text-tables with multi-line cells. 
(I invite the discussion of what features would be better to enable that in this very same PR - 
although merging it as is will be mostly harmless - the output of the text plug-in is supposed to be pretty, but it is a dangerous road to ensure data integrity round-trip between its output and back - multi-line cells will complicate a lot the current logic)