### PR TITLE
Display GitHub links in the docs (closes #326)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,8 @@
 site_name: rows 0.4.1 documentation
+
+repo_url: https://github.com/turicas/rows/
+edit_uri: edit/develop/docs/
+
 nav:
   - First Steps:
     - 'basic-usage.md'


### PR DESCRIPTION
`mkdocs` and the current theme support links to the GitHub project.

![Have a look at the links](https://user-images.githubusercontent.com/69548/81637643-3a211400-93ed-11ea-87a6-e4d359d7f9c6.png)

I think it closes #326 