### PR TITLE
plugin_json: fix usage with python3.9

### DIFF
--- a/rows/plugins/plugin_json.py
+++ b/rows/plugins/plugin_json.py
@@ -39,7 +39,7 @@ def import_from_json(filename_or_fobj, encoding="utf-8", *args, **kwargs):
 
     source = Source.from_file(filename_or_fobj, mode="rb", plugin_name="json", encoding=encoding)
 
-    json_obj = json.load(source.fobj, encoding=source.encoding)
+    json_obj = json.load(source.fobj)
     field_names = []
     for row in json_obj:
         for key in row.keys():


### PR DESCRIPTION
According to the python3.9 changelog, the encoding argument to
json.loads has been deprecated since python 3.1.