### PR TITLE
remove the obsolete TODO comment

### DIFF
--- a/rows/utils.py
+++ b/rows/utils.py
@@ -291,7 +291,6 @@ def plugin_name_by_uri(uri):
 def extension_by_source(source, mime_type):
     "Return the file extension used by this plugin"
 
-    # TODO: should get this information from the plugin
     extension = source.plugin_name
     if extension:
         return extension


### PR DESCRIPTION
##### SUMMARY
Remove the obsolete TODO comment. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rows/utils.py (line:294)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The pending task of the TODO comment has already performed in the earlier version, but the TODO comment was not removed accordingly at the moment. Please check the following commit: https://github.com/turicas/rows/commit/063eff251c5e013589454672af75c21492693fd2