### PR TITLE
Removing pathlib from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,7 @@ EXTRA_REQUIREMENTS = {
 }
 EXTRA_REQUIREMENTS["all"] = sum(EXTRA_REQUIREMENTS.values(), [])
 INSTALL_REQUIREMENTS = [
-    "dataclasses",
-    "pathlib",
+    "dataclasses",    
     "six",
     "requests",
 ] + EXTRA_REQUIREMENTS["csv"]


### PR DESCRIPTION
If you try to install pathlib em python3.9 or greater you receive a error cause Pathlib is now a native module from python and you will overwrite the original module.

https://docs.python.org/3/library/pathlib.html