### PR TITLE
Replace unicodecsv by standard csv module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ with open(version_filename, mode="r", encoding="utf-8") as fobj:
 utils_requirements = ["requests", "requests-cache", "tqdm"]
 EXTRA_REQUIREMENTS = {
     "cli": ["click"] + utils_requirements,
-    "csv": ["unicodecsv"],
     "detect": ["file-magic"],
     "html": ["lxml"],  # apt: libxslt-dev libxml2-dev
     "ods": ["lxml"],
@@ -46,10 +45,10 @@ EXTRA_REQUIREMENTS = {
 }
 EXTRA_REQUIREMENTS["all"] = sum(EXTRA_REQUIREMENTS.values(), [])
 INSTALL_REQUIREMENTS = [
-    "dataclasses",    
+    "dataclasses",
     "six",
     "requests",
-] + EXTRA_REQUIREMENTS["csv"]
+]
 LONG_DESCRIPTION = """
 No matter in which format your tabular data is: rows will import it,
 automatically detect types and give you high-level Python objects so you can


### PR DESCRIPTION
unicodecsv is not maintained since a while now [1].
It was preferred over standard csv because of the
unicode support. Now that Python3 csv module [2]
supports it, let's use it.

For more context, we hit issues while rebuilding
uncicodecsv during Fedora Python3.11 mass rebuild [3][4].

[1] https://github.com/jdunck/python-unicodecsv
[2] https://docs.python.org/3/library/csv.html
[3] https://copr.fedorainfracloud.org/coprs/g/python/python3.11/package/python-unicodecsv/
[4] https://bugzilla.redhat.com/show_bug.cgi?id=2021938