### PR TITLE
setup.py: fix Invalid version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ version_filename = convert_path("rows/__init__.py")
 with open(version_filename, mode="r", encoding="utf-8") as fobj:
     for line in fobj:
         if "__version__ =" in line:
-            version = line.strip().split("=")[-1].strip()
+            version = line.strip().split("=")[-1].strip().replace('"', '')
 
 utils_requirements = ["requests", "requests-cache", "tqdm"]
 EXTRA_REQUIREMENTS = {


### PR DESCRIPTION
While trying to build wors with setuptools 66 (e.g. `python3 setup.py sdist`), the following exception is raised:

	pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: '-0.4.2-dev-71afc647-'

setuptools 66 is more strict with version numbers. Since we read the Python code manually to extract the version, we also need to remove the quotes from the string literal representation.